### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Starter files for building application documentation
 
 
 See the `Documentation for documenting applications
-<http://application-documentation.readthedocs.org>`_ for more guidance on building and writing
+<https://application-documentation.readthedocs.io>`_ for more guidance on building and writing
 documentation.
 
 
@@ -15,8 +15,8 @@ How to use these starter files
 For a brand-new project
 =======================
 
-* Follow the directions for `setting up <http://application-documentation.readthedocs.org>`_ and
-  then `configuring <http://application-documentation.readthedocs.org>`_ your documentation.
+* Follow the directions for `setting up <https://application-documentation.readthedocs.io>`_ and
+  then `configuring <https://application-documentation.readthedocs.io>`_ your documentation.
 
 * ``git clone git@github.com:divio/application-documentation-starter-files.git`` (i.e. this
   repository) into another directory.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
